### PR TITLE
Improve hex viewer layout in GUI

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -13,7 +13,7 @@ class QTreeWidgetItem;
 class QLineEdit;
 class QComboBox;
 class QCheckBox;
-class QPlainTextEdit;
+class QTableWidget;
 class QLabel;
 class QPushButton;
 class CaptureWorker;
@@ -43,7 +43,7 @@ private:
     QSqlDatabase offsetsDb;
 
     QTreeWidget *tree;
-    QPlainTextEdit *packetView;
+    QTableWidget *packetView;
     QLineEdit *ipEdit;
     QLineEdit *portEdit;
     QLineEdit *protoEdit;


### PR DESCRIPTION
## Summary
- use `QTableWidget` for packet dump display
- enable monospace font for hex view
- add colored row/column headers and ASCII column

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6845b1a88dc0832bb0bbff8a8e740159